### PR TITLE
feat: add confetti celebration for successful transforms

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,32 +11,39 @@
   inset: 0;
   pointer-events: none;
   overflow: hidden;
-  z-index: 30;
+  z-index: 50;
 }
 
 .confetti-piece {
   position: absolute;
-  top: -10%;
+  top: 0;
   border-radius: 2px;
   opacity: 0;
   animation-name: confetti-fall;
   animation-timing-function: cubic-bezier(0.12, 0.8, 0.25, 1);
   animation-fill-mode: forwards;
+  will-change: transform, opacity;
 }
 
 @keyframes confetti-fall {
   0% {
-    opacity: 0;
-    transform: translate3d(0, -5vh, 0)
+    opacity: 0.15;
+    transform: translate3d(0, var(--confetti-start-y, -12vh), 0)
       rotate(var(--confetti-rotation-start, 0deg));
   }
 
-  12% {
+  10% {
     opacity: 1;
   }
 
+  55% {
+    opacity: 0.95;
+    transform: translate3d(calc(var(--confetti-drift, 0px) * 0.65), 58vh, 0)
+      rotate(calc(var(--confetti-rotation-start, 0deg) + 360deg));
+  }
+
   100% {
-    opacity: 0;
+    opacity: 0.05;
     transform: translate3d(var(--confetti-drift, 0px), 110vh, 0)
       rotate(calc(var(--confetti-rotation-start, 0deg) + 540deg));
   }
@@ -45,5 +52,12 @@
 @media (prefers-reduced-motion: reduce) {
   .confetti-piece {
     animation: none;
+    opacity: 0.95;
+    transform: translate3d(
+        var(--confetti-drift, 0px),
+        var(--confetti-static-y, 18vh),
+        0
+      )
+      rotate(var(--confetti-rotation-start, 0deg));
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -5,3 +5,45 @@
     "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "Roboto",
     "Helvetica Neue", "Arial", sans-serif;
 }
+
+.confetti-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 30;
+}
+
+.confetti-piece {
+  position: absolute;
+  top: -10%;
+  border-radius: 2px;
+  opacity: 0;
+  animation-name: confetti-fall;
+  animation-timing-function: cubic-bezier(0.12, 0.8, 0.25, 1);
+  animation-fill-mode: forwards;
+}
+
+@keyframes confetti-fall {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, -5vh, 0)
+      rotate(var(--confetti-rotation-start, 0deg));
+  }
+
+  12% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate3d(var(--confetti-drift, 0px), 110vh, 0)
+      rotate(calc(var(--confetti-rotation-start, 0deg) + 540deg));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .confetti-piece {
+    animation: none;
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -50,14 +50,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .confetti-piece {
-    animation: none;
-    opacity: 0.95;
-    transform: translate3d(
-        var(--confetti-drift, 0px),
-        var(--confetti-static-y, 18vh),
-        0
-      )
-      rotate(var(--confetti-rotation-start, 0deg));
+  .confetti-overlay {
+    display: none;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,19 +23,38 @@ const CONFETTI_COLORS = [
   "#8b5cf6",
   "#14b8a6",
 ];
-const CONFETTI_COUNT = 40;
+const CONFETTI_COUNT = 140;
+const CONFETTI_MAX_DELAY_MS = 220;
+const CONFETTI_MIN_DURATION_MS = 2800;
+const CONFETTI_DURATION_VARIANCE_MS = 1200;
+const CONFETTI_HIDE_AFTER_MS =
+  CONFETTI_MAX_DELAY_MS +
+  CONFETTI_MIN_DURATION_MS +
+  CONFETTI_DURATION_VARIANCE_MS +
+  300;
+
+type ConfettiStyle = CSSProperties & {
+  "--confetti-drift": string;
+  "--confetti-start-y": string;
+  "--confetti-static-y": string;
+  "--confetti-rotation-start": string;
+};
 
 const getConfettiPieceStyle = (
   index: number,
   burstId: number,
-): CSSProperties => {
+): ConfettiStyle => {
   const spread = (index / (CONFETTI_COUNT - 1)) * 100;
-  const jitter = ((index * 37 + burstId * 19) % 10) - 5;
-  const delayMs = (index % 8) * 45;
-  const durationMs = 1600 + ((index * 71 + burstId * 13) % 900);
-  const driftPx = ((index * 29 + burstId * 11) % 120) - 60;
+  const jitter = ((index * 37 + burstId * 19) % 14) - 7;
+  const delayMs = (index * 47 + burstId * 29) % CONFETTI_MAX_DELAY_MS;
+  const durationMs =
+    CONFETTI_MIN_DURATION_MS +
+    ((index * 71 + burstId * 13) % CONFETTI_DURATION_VARIANCE_MS);
+  const driftPx = ((index * 29 + burstId * 11) % 180) - 90;
+  const startYVh = -((index * 31 + burstId * 17) % 28);
+  const staticYVh = 10 + ((index * 23 + burstId * 7) % 60);
   const rotationDeg = (index * 47 + burstId * 31) % 360;
-  const widthPx = 6 + ((index * 17 + burstId * 7) % 7);
+  const widthPx = 5 + ((index * 17 + burstId * 7) % 9);
   const heightPx = Math.max(4, Math.round(widthPx * 0.45));
 
   return {
@@ -46,8 +65,10 @@ const getConfettiPieceStyle = (
     width: `${widthPx}px`,
     height: `${heightPx}px`,
     "--confetti-drift": `${driftPx}px`,
+    "--confetti-start-y": `${startYVh}vh`,
+    "--confetti-static-y": `${staticYVh}vh`,
     "--confetti-rotation-start": `${rotationDeg}deg`,
-  } as CSSProperties;
+  };
 };
 
 function App() {
@@ -90,7 +111,7 @@ function App() {
 
     const timer = window.setTimeout(() => {
       setShowConfetti(false);
-    }, 2600);
+    }, CONFETTI_HIDE_AFTER_MS);
 
     return () => window.clearTimeout(timer);
   }, [showConfetti]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, type DragEvent, type ChangeEvent } from "react";
+import {
+  useState,
+  useEffect,
+  type CSSProperties,
+  type DragEvent,
+  type ChangeEvent,
+} from "react";
 import "./App.css";
 
 // API URL configuration
@@ -9,6 +15,41 @@ const API_URL =
   import.meta.env.VITE_API_URL ||
   (import.meta.env.DEV ? "http://localhost:8000" : "/api");
 
+const CONFETTI_COLORS = [
+  "#f43f5e",
+  "#f59e0b",
+  "#22c55e",
+  "#3b82f6",
+  "#8b5cf6",
+  "#14b8a6",
+];
+const CONFETTI_COUNT = 40;
+
+const getConfettiPieceStyle = (
+  index: number,
+  burstId: number,
+): CSSProperties => {
+  const spread = (index / (CONFETTI_COUNT - 1)) * 100;
+  const jitter = ((index * 37 + burstId * 19) % 10) - 5;
+  const delayMs = (index % 8) * 45;
+  const durationMs = 1600 + ((index * 71 + burstId * 13) % 900);
+  const driftPx = ((index * 29 + burstId * 11) % 120) - 60;
+  const rotationDeg = (index * 47 + burstId * 31) % 360;
+  const widthPx = 6 + ((index * 17 + burstId * 7) % 7);
+  const heightPx = Math.max(4, Math.round(widthPx * 0.45));
+
+  return {
+    left: `${Math.max(0, Math.min(100, spread + jitter))}%`,
+    animationDelay: `${delayMs}ms`,
+    animationDuration: `${durationMs}ms`,
+    backgroundColor: CONFETTI_COLORS[index % CONFETTI_COLORS.length],
+    width: `${widthPx}px`,
+    height: `${heightPx}px`,
+    "--confetti-drift": `${driftPx}px`,
+    "--confetti-rotation-start": `${rotationDeg}deg`,
+  } as CSSProperties;
+};
+
 function App() {
   const [file, setFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -16,6 +57,8 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
   const [isOnline, setIsOnline] = useState<boolean | null>(null);
+  const [showConfetti, setShowConfetti] = useState(false);
+  const [confettiBurstId, setConfettiBurstId] = useState(0);
 
   // Cleanup download URL on unmount
   useEffect(() => {
@@ -41,6 +84,16 @@ function App() {
     };
     checkHealth();
   }, []);
+
+  useEffect(() => {
+    if (!showConfetti) return;
+
+    const timer = window.setTimeout(() => {
+      setShowConfetti(false);
+    }, 2600);
+
+    return () => window.clearTimeout(timer);
+  }, [showConfetti]);
 
   const clearDownloadUrl = () => {
     if (downloadUrl) {
@@ -133,6 +186,8 @@ function App() {
       const blob = await response.blob();
       const url = URL.createObjectURL(blob);
       setDownloadUrl(url);
+      setConfettiBurstId((prev) => prev + 1);
+      setShowConfetti(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {
@@ -163,6 +218,22 @@ function App() {
 
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center p-8">
+      {showConfetti && (
+        <div
+          className="confetti-overlay"
+          aria-hidden="true"
+          key={confettiBurstId}
+        >
+          {Array.from({ length: CONFETTI_COUNT }).map((_, index) => (
+            <span
+              key={`${confettiBurstId}-${index}`}
+              className="confetti-piece"
+              style={getConfettiPieceStyle(index, confettiBurstId)}
+            />
+          ))}
+        </div>
+      )}
+
       <div className="max-w-xl w-full">
         {/* Header */}
         <div className="text-center mb-8">
@@ -288,7 +359,7 @@ function App() {
         {downloadUrl && (
           <div className="mt-4 p-4 bg-green-50 border border-green-200 rounded-lg">
             <p className="text-green-700 text-sm mb-3">
-              Transformation complete!
+              Transformation complete! 🎉
             </p>
             <button
               onClick={handleDownload}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,6 @@ const CONFETTI_HIDE_AFTER_MS =
 type ConfettiStyle = CSSProperties & {
   "--confetti-drift": string;
   "--confetti-start-y": string;
-  "--confetti-static-y": string;
   "--confetti-rotation-start": string;
 };
 
@@ -52,7 +51,6 @@ const getConfettiPieceStyle = (
     ((index * 71 + burstId * 13) % CONFETTI_DURATION_VARIANCE_MS);
   const driftPx = ((index * 29 + burstId * 11) % 180) - 90;
   const startYVh = -((index * 31 + burstId * 17) % 28);
-  const staticYVh = 10 + ((index * 23 + burstId * 7) % 60);
   const rotationDeg = (index * 47 + burstId * 31) % 360;
   const widthPx = 5 + ((index * 17 + burstId * 7) % 9);
   const heightPx = Math.max(4, Math.round(widthPx * 0.45));
@@ -66,7 +64,6 @@ const getConfettiPieceStyle = (
     height: `${heightPx}px`,
     "--confetti-drift": `${driftPx}px`,
     "--confetti-start-y": `${startYVh}vh`,
-    "--confetti-static-y": `${staticYVh}vh`,
     "--confetti-rotation-start": `${rotationDeg}deg`,
   };
 };


### PR DESCRIPTION
## Summary
- add a lightweight confetti animation overlay that triggers when a transform request succeeds
- keep celebration non-intrusive by auto-hiding after a short duration and leaving existing success/download flow intact
- respect reduced-motion preferences by disabling the confetti animation for users who opt out of motion

## Testing
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a celebratory confetti overlay that appears after a successful image transformation
  * Success message now includes a celebration emoji
  * Overlay is non-interactive, respects prefers-reduced-motion, and automatically dismisses after the celebration period (~2.6s)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->